### PR TITLE
Trim header row values

### DIFF
--- a/projects/ngx-csv-parser/src/lib/ngx-csv-parser.service.ts
+++ b/projects/ngx-csv-parser/src/lib/ngx-csv-parser.service.ts
@@ -103,7 +103,7 @@ export class NgxCsvParser {
         config: any
     ) {
         const dataArr = [];
-        const headersArray = csvRecordsArray[0];
+        const headersArray = csvRecordsArray[0].map((h: string) => h.trim());
 
         const startingRowToParseData = config.header ? 1 : 0;
 
@@ -136,7 +136,7 @@ export class NgxCsvParser {
         const headers = csvRecordsArr[0];
         const headerArray = [];
         for (const header of headers) {
-            headerArray.push(header);
+            headerArray.push(header.trim());
         }
         return headerArray;
     }


### PR DESCRIPTION
Hi!

This PR addresses the case where row header values have leading/trailing spaces and further data retrieval fails since you're accessing `row['email']` and the acual header title is `email `.